### PR TITLE
fix: possible fix for profile not at 100% width

### DIFF
--- a/adlerweg/index.html
+++ b/adlerweg/index.html
@@ -61,7 +61,7 @@
         <select id="pulldown"></select>
         <div id="map"></div>
         <a id="et-track"></a></br>
-        <div id="profile" class="optional"></div>
+        <div id="profile" style="visibility: hidden;"></div>
         <div class="optional">
             <h3>Etappenübersicht</h3>
             <ul id="liste">

--- a/adlerweg/main.js
+++ b/adlerweg/main.js
@@ -76,6 +76,7 @@ let drawEtappe = function (nr) {
         map.fitBounds(overlay.adlerblicke.getBounds()); //Mapbounds auf Adlerblicke
         // visibility = document.getElementsByClassName("optional-visible").style = "optional-hidden";
         vis = document.getElementsByClassName("optional");
+        document.getElementById("profile").style.visibility = "hidden";
         for (let i = 0; i < vis.length; i++) {
             vis[i].style.display = "none";
         }
@@ -93,6 +94,7 @@ let drawEtappe = function (nr) {
 
     } else {
         // visibility = document.getElementsByClassName("optional-hidden").className = "optional-visible";
+        document.getElementById("profile").style.visibility = "visible";
         vis = document.getElementsByClassName("optional");
         for (let i = 0; i < vis.length; i++) {
             vis[i].style.display = "inline";


### PR DESCRIPTION
Das wäre eine Möglichkeit, wie das Profil auf 100% angezeigt wird. Das Problem ist, dass das Element `#profile` zum Zeitpunkt des Ladens im DOM-Baum mit `display: none` eingehängt ist. Das  (blöde) Plugin nur richtig, wenn das beim Laden schon seine Dimensionen kennt. Mit `visibility: hidden` ist es mit der korrekten Größe im DOM, aber eben nicht angezeigt. Ich hoffe das hilft.